### PR TITLE
Improve focus metrics aggregation and popup reporting

### DIFF
--- a/productivity assistance/chrome tab tracker/CONTRIBUTING.md
+++ b/productivity assistance/chrome tab tracker/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contribution Guide
+
+If you only want to include changes from specific files in a pull request, stage just those files before committing:
+
+1. Review the files you modified:
+   ```bash
+   git status
+   ```
+2. Stage only the files that belong in the pull request:
+   ```bash
+   git add path/to/file-one.js path/to/file-two.js
+   ```
+3. Confirm that only the desired files are staged:
+   ```bash
+   git status
+   ```
+   The files you listed with `git add` will appear under "Changes to be committed".
+4. Commit and push the selective changes:
+   ```bash
+   git commit -m "Describe your change"
+   git push
+   ```
+5. Open the pull request on your hosting service (e.g., GitHub). It will only show the files included in the commit.
+
+To remove a mistakenly staged file, run `git restore --staged path/to/file.js` before committing.

--- a/productivity assistance/chrome tab tracker/background.js
+++ b/productivity assistance/chrome tab tracker/background.js
@@ -1,5 +1,6 @@
 // === FlowScope Background Service Worker ===
 import { estimateFocus } from "./algorithm.js";
+
 // Note: background.js runs in a service worker context
 // Install/startup logs
 chrome.runtime.onInstalled.addListener(() => {
@@ -7,10 +8,73 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 console.log("Background service worker loaded 🎉");
 
+// === In-memory metric tracking ===
+
+const MAX_EVENT_AGE_MS = 15 * 60 * 1000; // retain 15 minutes of history for metrics
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const history = {
+  tabSwitches: [],
+  scrolls: [],
+  inputs: [],
+};
+
+let currentActivityState = "active";
+let currentActivitySince = Date.now();
+const activitySegments = [];
+let currentDayKey = getTodayKey();
+let tabSwitchCount = 0;
+
+function normalizeState(state) {
+  return state === "idle" || state === "locked" ? "idle" : "active";
+}
+
+function pruneOldEvents(list, cutoff) {
+  while (list.length && list[0].time < cutoff) {
+    list.shift();
+  }
+}
+
+function pruneActivity(cutoff) {
+  while (activitySegments.length && activitySegments[0].end <= cutoff) {
+    activitySegments.shift();
+  }
+}
+
+function recordActivityTransition(newState) {
+  const now = Date.now();
+  activitySegments.push({
+    state: currentActivityState,
+    start: currentActivitySince,
+    end: now,
+  });
+  currentActivityState = normalizeState(newState);
+  currentActivitySince = now;
+  const cutoff = now - MAX_EVENT_AGE_MS;
+  pruneActivity(cutoff);
+}
+
+function recordEvent(list, payload = {}) {
+  const now = Date.now();
+  list.push({ time: now, ...payload });
+  const cutoff = now - MAX_EVENT_AGE_MS;
+  pruneOldEvents(list, cutoff);
+}
+
 // --- Utility Functions ---
 
 function getTodayKey() {
   return new Date().toISOString().split("T")[0]; // e.g. "2025-09-19"
+}
+
+function ensureCurrentDay() {
+  const today = getTodayKey();
+  if (today !== currentDayKey) {
+    currentDayKey = today;
+    tabSwitchCount = 0;
+  }
+  return currentDayKey;
 }
 
 // Get ISO week key: "YYYY-Wxx"
@@ -30,25 +94,8 @@ function getISOWeekKey(date) {
   return `${tempDate.getFullYear()}-W${weekNumber}`;
 }
 
-// --- Storage Functions ---
-
-function saveTabSwitchCount(count) {
-  const today = getTodayKey();
-
-  chrome.storage.local.get(null, (data) => {
-    let todayData = data[today] || { tabSwitches: 0, idleTime: 0 };
-    todayData.tabSwitches = count;
-
-    chrome.storage.local.set({ [today]: todayData }, () => {
-      console.log("Saved tab switch count:", todayData);
-    });
-
-    cleanupOldEntries(data);
-  });
-}
-
 function cleanupOldEntries(data) {
-  const allDates = Object.keys(data).filter((k) => k.includes("-"));
+  const allDates = Object.keys(data).filter((k) => DATE_KEY_PATTERN.test(k));
   allDates.sort(); // oldest → newest
   const maxDays = 7;
 
@@ -87,58 +134,174 @@ function cleanupOldEntries(data) {
   }
 }
 
-// --- Tab & Window Tracking ---
+function withTodayData(mutator) {
+  const today = ensureCurrentDay();
+  chrome.storage.local.get(null, (data) => {
+    const todayData = {
+      tabSwitches: 0,
+      idleTime: 0,
+      scroll: {},
+      ...(data[today] || {}),
+    };
 
-let tabSwitchCount = 0;
+    todayData.tabSwitches = tabSwitchCount;
+
+    if (typeof mutator === "function") {
+      mutator(todayData);
+    }
+
+    chrome.storage.local.set({ [today]: todayData }, () => {
+      console.log("Saved today data:", todayData);
+    });
+
+    const updatedData = { ...data, [today]: todayData };
+    cleanupOldEntries(updatedData);
+  });
+}
+
+function handleTabSwitch() {
+  ensureCurrentDay();
+  tabSwitchCount += 1;
+  recordEvent(history.tabSwitches);
+  withTodayData(() => {});
+  console.log("Tab/window switch recorded. Total:", tabSwitchCount);
+}
 
 // Fired when user switches to a new tab
 chrome.tabs.onActivated.addListener(() => {
-  tabSwitchCount++;
-  console.log("Tab switched! Total:", tabSwitchCount);
-  saveTabSwitchCount(tabSwitchCount);
+  handleTabSwitch();
 });
 
 // Fired when user switches between Chrome windows
 chrome.windows.onFocusChanged.addListener((windowId) => {
   if (windowId !== chrome.windows.WINDOW_ID_NONE) {
-    tabSwitchCount++;
-    console.log("Window focus changed. Total switches:", tabSwitchCount);
-    saveTabSwitchCount(tabSwitchCount);
+    handleTabSwitch();
   }
 });
-
 
 // Idle tracking: user inactive >30s
 chrome.idle.setDetectionInterval(30);
 
 chrome.idle.onStateChanged.addListener((newState) => {
   console.log("Idle state changed:", newState);
-  saveTodayData((todayData) => {
-    if (newState === "idle" || newState === "locked") {
+  recordActivityTransition(newState);
+  withTodayData((todayData) => {
+    if (normalizeState(newState) === "idle") {
       todayData.idleTime += 30; // rough approximation
     }
   });
 });
 
-
-// --- Scroll Tracking ---
+// --- Message Handling ---
 chrome.runtime.onMessage.addListener((msg, sender) => {
   if (msg.type === "scroll") {
-    saveTodayData((todayData) => {
-      if (!todayData.scroll) todayData.scroll = {};
-      if (!todayData.scroll[msg.url]) todayData.scroll[msg.url] = { distance: 0, events: 0 };
+    const urlKey = msg.url || "unknown";
+    recordEvent(history.scrolls, { distance: msg.distance, speed: msg.speed });
+    withTodayData((todayData) => {
+      if (!todayData.scroll[urlKey]) {
+        todayData.scroll[urlKey] = { distance: 0, events: 0 };
+      }
 
-      todayData.scroll[msg.url].distance += msg.distance;
-      todayData.scroll[msg.url].events += 1;
+      todayData.scroll[urlKey].distance += msg.distance;
+      todayData.scroll[urlKey].events += 1;
+    });
+  } else if (msg.type === "input-activity") {
+    recordEvent(history.inputs, {
+      keys: msg.keys,
+      mouseDistance: msg.mouseDistance,
+      mouseEvents: msg.mouseEvents,
     });
   }
 });
 
+// --- Focus Metrics Aggregation ---
+function sumFromEvents(events, startTime, accessor) {
+  return events.reduce((total, event) => {
+    return event.time >= startTime ? total + accessor(event) : total;
+  }, 0);
+}
+
+function collectWindowMetrics(windowSeconds) {
+  const now = Date.now();
+  const windowMs = windowSeconds * 1000;
+  const startTime = now - windowMs;
+
+  pruneOldEvents(history.tabSwitches, now - MAX_EVENT_AGE_MS);
+  pruneOldEvents(history.scrolls, now - MAX_EVENT_AGE_MS);
+  pruneOldEvents(history.inputs, now - MAX_EVENT_AGE_MS);
+  pruneActivity(now - MAX_EVENT_AGE_MS);
+
+  const switchesInWindow = history.tabSwitches.filter((event) => event.time >= startTime);
+  const switchRate = switchesInWindow.length === 0
+    ? 0
+    : (switchesInWindow.length / windowSeconds) * 60;
+
+  const keyCount = sumFromEvents(history.inputs, startTime, (event) => event.keys || 0);
+  const keyRate = windowSeconds > 0 ? keyCount / windowSeconds : 0;
+
+  const totalMouseDistance = sumFromEvents(
+    history.inputs,
+    startTime,
+    (event) => event.mouseDistance || 0
+  );
+  const mouseRate = windowSeconds > 0 ? totalMouseDistance / windowSeconds : 0;
+
+  const totalScroll = sumFromEvents(history.scrolls, startTime, (event) => event.distance || 0);
+  const scrollRate = windowSeconds > 0 ? totalScroll / windowSeconds : 0;
+
+  const activeMs = (() => {
+    let activeDuration = 0;
+
+    activitySegments.forEach((segment) => {
+      const segmentStart = Math.max(segment.start, startTime);
+      const segmentEnd = Math.min(segment.end, now);
+      if (segmentEnd > segmentStart && segment.state === "active") {
+        activeDuration += segmentEnd - segmentStart;
+      }
+    });
+
+    const ongoingSegmentEnd = now;
+    const ongoingStart = Math.max(currentActivitySince, startTime);
+    if (ongoingSegmentEnd > ongoingStart && currentActivityState === "active") {
+      activeDuration += ongoingSegmentEnd - ongoingStart;
+    }
+
+    return activeDuration;
+  })();
+
+  const activeFrac = windowMs > 0 ? activeMs / windowMs : 0;
+
+  let stddev = 0.3;
+  if (switchesInWindow.length >= 2) {
+    const intervals = [];
+    for (let i = 1; i < switchesInWindow.length; i += 1) {
+      intervals.push((switchesInWindow[i].time - switchesInWindow[i - 1].time) / 1000);
+    }
+    if (intervals.length > 0) {
+      const mean = intervals.reduce((sum, val) => sum + val, 0) / intervals.length;
+      const variance = intervals.reduce((sum, val) => sum + (val - mean) ** 2, 0) / intervals.length;
+      stddev = Math.min(1, Math.sqrt(variance) / 60);
+    }
+  }
+
+  return {
+    activeFrac: Math.max(0, Math.min(1, activeFrac)),
+    switchRate,
+    keyRate,
+    mouseRate,
+    scrollRate,
+    notifyRate: 0,
+    mediaFlag: 0,
+    stddev,
+  };
+}
+
 // --- Focus Estimation ---
 function updateEstimate() {
-  const W1 = collectWindowMetrics(15);   // implement to return object with rates
+  const W1 = collectWindowMetrics(15);
   const W2 = collectWindowMetrics(120);
   const result = estimateFocus(W1, W2);
   chrome.storage.local.set({ focusEstimate: result });
 }
+updateEstimate();
 setInterval(updateEstimate, 5000);

--- a/productivity assistance/chrome tab tracker/background.js
+++ b/productivity assistance/chrome tab tracker/background.js
@@ -25,6 +25,7 @@ let currentActivitySince = Date.now();
 const activitySegments = [];
 let currentDayKey = getTodayKey();
 let tabSwitchCount = 0;
+let estimateUpdateTimer = null;
 
 function normalizeState(state) {
   return state === "idle" || state === "locked" ? "idle" : "active";
@@ -43,13 +44,17 @@ function pruneActivity(cutoff) {
 }
 
 function recordActivityTransition(newState) {
+  const normalizedState = normalizeState(newState);
+  if (normalizedState === currentActivityState) {
+    return;
+  }
   const now = Date.now();
   activitySegments.push({
     state: currentActivityState,
     start: currentActivitySince,
     end: now,
   });
-  currentActivityState = normalizeState(newState);
+  currentActivityState = normalizedState;
   currentActivitySince = now;
   const cutoff = now - MAX_EVENT_AGE_MS;
   pruneActivity(cutoff);
@@ -124,12 +129,20 @@ function cleanupOldEntries(data) {
         },
       },
       () => {
-        console.log("Archived weekly summary:", weekKey);
+        if (chrome.runtime.lastError) {
+          console.error("Failed to archive weekly summary:", chrome.runtime.lastError);
+        } else {
+          console.log("Archived weekly summary:", weekKey);
+        }
       }
     );
 
     chrome.storage.local.remove(toArchive, () => {
-      console.log("Removed old entries:", toArchive);
+      if (chrome.runtime.lastError) {
+        console.error("Failed to remove old entries:", chrome.runtime.lastError);
+      } else {
+        console.log("Removed old entries:", toArchive);
+      }
     });
   }
 }
@@ -137,6 +150,10 @@ function cleanupOldEntries(data) {
 function withTodayData(mutator) {
   const today = ensureCurrentDay();
   chrome.storage.local.get(null, (data) => {
+    if (chrome.runtime.lastError) {
+      console.error("Failed to read storage:", chrome.runtime.lastError);
+      return;
+    }
     const todayData = {
       tabSwitches: 0,
       idleTime: 0,
@@ -151,11 +168,30 @@ function withTodayData(mutator) {
     }
 
     chrome.storage.local.set({ [today]: todayData }, () => {
+      if (chrome.runtime.lastError) {
+        console.error("Failed to persist today data:", chrome.runtime.lastError);
+        return;
+      }
       console.log("Saved today data:", todayData);
+      requestEstimateUpdate();
     });
 
     const updatedData = { ...data, [today]: todayData };
     cleanupOldEntries(updatedData);
+  });
+}
+
+function initializeTodayState() {
+  const today = ensureCurrentDay();
+  chrome.storage.local.get(today, (data) => {
+    if (chrome.runtime.lastError) {
+      console.error("Failed to initialize today state:", chrome.runtime.lastError);
+      return;
+    }
+    const saved = data[today];
+    if (saved && typeof saved.tabSwitches === "number") {
+      tabSwitchCount = saved.tabSwitches;
+    }
   });
 }
 
@@ -165,6 +201,7 @@ function handleTabSwitch() {
   recordEvent(history.tabSwitches);
   withTodayData(() => {});
   console.log("Tab/window switch recorded. Total:", tabSwitchCount);
+  requestEstimateUpdate();
 }
 
 // Fired when user switches to a new tab
@@ -193,7 +230,7 @@ chrome.idle.onStateChanged.addListener((newState) => {
 });
 
 // --- Message Handling ---
-chrome.runtime.onMessage.addListener((msg, sender) => {
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === "scroll") {
     const urlKey = msg.url || "unknown";
     recordEvent(history.scrolls, { distance: msg.distance, speed: msg.speed });
@@ -205,13 +242,16 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
       todayData.scroll[urlKey].distance += msg.distance;
       todayData.scroll[urlKey].events += 1;
     });
+    requestEstimateUpdate();
   } else if (msg.type === "input-activity") {
     recordEvent(history.inputs, {
       keys: msg.keys,
       mouseDistance: msg.mouseDistance,
       mouseEvents: msg.mouseEvents,
     });
+    requestEstimateUpdate();
   }
+  return false;
 });
 
 // --- Focus Metrics Aggregation ---
@@ -297,11 +337,36 @@ function collectWindowMetrics(windowSeconds) {
 }
 
 // --- Focus Estimation ---
+function requestEstimateUpdate(immediate = false) {
+  if (immediate) {
+    if (estimateUpdateTimer) {
+      clearTimeout(estimateUpdateTimer);
+      estimateUpdateTimer = null;
+    }
+    updateEstimate();
+    return;
+  }
+
+  if (estimateUpdateTimer) {
+    return;
+  }
+
+  estimateUpdateTimer = setTimeout(() => {
+    estimateUpdateTimer = null;
+    updateEstimate();
+  }, 750);
+}
+
 function updateEstimate() {
   const W1 = collectWindowMetrics(15);
   const W2 = collectWindowMetrics(120);
   const result = estimateFocus(W1, W2);
-  chrome.storage.local.set({ focusEstimate: result });
+  chrome.storage.local.set({ focusEstimate: result }, () => {
+    if (chrome.runtime.lastError) {
+      console.error("Failed to persist focus estimate:", chrome.runtime.lastError);
+    }
+  });
 }
+initializeTodayState();
 updateEstimate();
 setInterval(updateEstimate, 5000);

--- a/productivity assistance/chrome tab tracker/content.js
+++ b/productivity assistance/chrome tab tracker/content.js
@@ -10,6 +10,13 @@ const inputBuffer = {
 
 let flushTimer = null;
 
+function clearFlushTimer() {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+}
+
 function scheduleFlush() {
   if (flushTimer) {
     return;
@@ -21,6 +28,7 @@ function scheduleFlush() {
 }
 
 function flushInputBuffer() {
+  clearFlushTimer();
   if (inputBuffer.keys === 0 && inputBuffer.mouseEvents === 0 && inputBuffer.mouseDistance === 0) {
     return;
   }

--- a/productivity assistance/chrome tab tracker/content.js
+++ b/productivity assistance/chrome tab tracker/content.js
@@ -1,22 +1,84 @@
 let lastScrollY = window.scrollY;
-let lastTime = Date.now();
+let lastScrollTime = Date.now();
+let lastMousePosition = { x: null, y: null };
+
+const inputBuffer = {
+  keys: 0,
+  mouseDistance: 0,
+  mouseEvents: 0,
+};
+
+let flushTimer = null;
+
+function scheduleFlush() {
+  if (flushTimer) {
+    return;
+  }
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flushInputBuffer();
+  }, 2000);
+}
+
+function flushInputBuffer() {
+  if (inputBuffer.keys === 0 && inputBuffer.mouseEvents === 0 && inputBuffer.mouseDistance === 0) {
+    return;
+  }
+
+  chrome.runtime.sendMessage({
+    type: "input-activity",
+    keys: inputBuffer.keys,
+    mouseDistance: inputBuffer.mouseDistance,
+    mouseEvents: inputBuffer.mouseEvents,
+  });
+
+  inputBuffer.keys = 0;
+  inputBuffer.mouseDistance = 0;
+  inputBuffer.mouseEvents = 0;
+}
 
 window.addEventListener("scroll", () => {
   const now = Date.now();
   const deltaY = Math.abs(window.scrollY - lastScrollY);
-  const deltaT = (now - lastTime) / 1000; // seconds
+  const deltaT = (now - lastScrollTime) / 1000; // seconds
 
-  if (deltaT > 0) {
+  if (deltaT > 0 && deltaY > 0) {
     const scrollSpeed = deltaY / deltaT; // px per second
 
     chrome.runtime.sendMessage({
       type: "scroll",
       url: location.hostname,
       speed: scrollSpeed,
-      distance: deltaY
+      distance: deltaY,
     });
   }
 
   lastScrollY = window.scrollY;
-  lastTime = now;
+  lastScrollTime = now;
+});
+
+window.addEventListener("keydown", () => {
+  inputBuffer.keys += 1;
+  scheduleFlush();
+});
+
+window.addEventListener("mousemove", (event) => {
+  if (lastMousePosition.x !== null && lastMousePosition.y !== null) {
+    const deltaX = event.clientX - lastMousePosition.x;
+    const deltaY = event.clientY - lastMousePosition.y;
+    inputBuffer.mouseDistance += Math.sqrt(deltaX ** 2 + deltaY ** 2);
+  }
+  lastMousePosition = { x: event.clientX, y: event.clientY };
+  inputBuffer.mouseEvents += 1;
+  scheduleFlush();
+});
+
+window.addEventListener("beforeunload", () => {
+  flushInputBuffer();
+});
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden") {
+    flushInputBuffer();
+  }
 });

--- a/productivity assistance/chrome tab tracker/popup.html
+++ b/productivity assistance/chrome tab tracker/popup.html
@@ -2,10 +2,40 @@
 <html>
   <head>
     <title>FlowScope</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 16px;
+        min-width: 240px;
+      }
+
+      h2 {
+        margin-top: 0;
+      }
+
+      .status {
+        margin-bottom: 8px;
+      }
+
+      .status-label {
+        font-weight: bold;
+      }
+    </style>
   </head>
   <body>
     <h2>FlowScope</h2>
-    <div id="output">Extension loaded.</div>
+    <div class="status">
+      <span class="status-label">Today:</span>
+      <span id="today">Loading…</span>
+    </div>
+    <div class="status">
+      <span class="status-label">Weekly summary:</span>
+      <span id="week">Loading…</span>
+    </div>
+    <div class="status">
+      <span class="status-label">Focus status:</span>
+      <span id="status">Loading…</span>
+    </div>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/productivity assistance/chrome tab tracker/popup.js
+++ b/productivity assistance/chrome tab tracker/popup.js
@@ -4,27 +4,45 @@ document.addEventListener("DOMContentLoaded", () => {
     const todayData = data[todayKey];
 
     // Today status
-    let todayStatus = todayData
-      ? "OK: Today’s entry exists"
-      : "X: No data collected today";
-    document.getElementById("today").textContent = todayStatus;
+    const todayElement = document.getElementById("today");
+    if (todayElement) {
+      if (todayData) {
+        const switches = todayData.tabSwitches ?? 0;
+        const idle = todayData.idleTime ?? 0;
+        todayElement.textContent = `Active switches: ${switches}, Idle time: ${idle}s`;
+      } else {
+        todayElement.textContent = "No data collected today";
+      }
+    }
 
     // Weekly summary status
     const weekKeys = Object.keys(data).filter((k) => k.includes("W"));
-    let weekStatus = weekKeys.length
-      ? `OK: ${weekKeys.length} weekly summaries available`
-      : "X: No weekly summary yet";
-    document.getElementById("week").textContent = weekStatus;
+    const weekElement = document.getElementById("week");
+    if (weekElement) {
+      if (weekKeys.length) {
+        const sortedKeys = weekKeys.slice().sort();
+        const latestKey = sortedKeys[sortedKeys.length - 1];
+        const summary = data[latestKey];
+        const switches = summary?.avgTabSwitches ?? 0;
+        const idle = summary?.avgIdleTime ?? 0;
+        weekElement.textContent = `${latestKey}: avg switches ${switches}, idle ${idle}s`;
+      } else {
+        weekElement.textContent = "No weekly summary yet";
+      }
+    }
   });
 
   chrome.storage.local.get("focusEstimate", (data) => {
     const e = data.focusEstimate;
+    const statusElement = document.getElementById("status");
+    if (!statusElement) {
+      return;
+    }
+
     if (e) {
-      document.getElementById("status").textContent =
-        `Score: ${e.focus_score}, Label: ${e.label}, Confidence: ${e.confidence}`;
+      statusElement.textContent = `Score: ${e.focus_score}, Label: ${e.label}, Confidence: ${e.confidence}`;
     } else {
-      document.getElementById("status").textContent =
-        "No focus estimate available yet";
+      statusElement.textContent = "No focus estimate available yet";
     }
   });
 });


### PR DESCRIPTION
## Summary
- add resilient metric tracking, day rollover handling, and focus estimation helpers in the background worker
- capture keyboard/mouse usage from the content script so focus scoring receives complete inputs
- refresh the popup UI to surface daily/weekly stats and the latest focus assessment

## Testing
- not run (Chrome extension environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6b34d5ba48329bbf07581cd8a56fe